### PR TITLE
Fixed audio/video content upload to github

### DIFF
--- a/pages/marker/marker.js
+++ b/pages/marker/marker.js
@@ -49,7 +49,7 @@ const enablePageFooter = (enable) => {
 const zip = () => {
     // TODO: replace alerts with HTML error messages.
     if (!window.markerImage) return alert('please select a marker image');
-    if (!window.assetType) return alert('please select the corret content type');
+    if (!window.assetType) return alert('please select the correct content type');
     if (!window.assetFile || !window.assetName) return alert('please upload a content');
 
     MarkerModule.getMarkerPattern(window.markerImage)
@@ -96,7 +96,6 @@ const publish = () => {
                 markerImage: window.markerImage,
                 fullMarkerImage: window.fullMarkerImage,
             });
-
             window.location = '../publish';
         }
         )

--- a/pages/publish-confirm/publish-confirm.js
+++ b/pages/publish-confirm/publish-confirm.js
@@ -4,6 +4,10 @@ window.onload = async () => {
 
     window.session = JSON.parse(window.name);
 
+    if (window.session.assetType === "audio" || window.session.assetType === "video") {
+        window.session.assetFile = new Uint8Array(window.session.assetFile).buffer;
+    }
+
     const queryDict = {}
     location.search.substr(1).split("&").forEach((item) => {
         queryDict[item.split("=")[0]] = item.split("=")[1]

--- a/utils/fileHandler.js
+++ b/utils/fileHandler.js
@@ -98,7 +98,7 @@ function handleAudioUpload(file) {
     reader.readAsArrayBuffer(file);
     reader.onloadend = function () {
         //for backend api asset needs only base64 part
-        window.assetFile = reader.result;
+        window.assetFile =  Array.from(new Uint8Array(reader.result));
         window.assetName = file.type.replace('audio/', 'asset.');
         checkUserUploadStatus();
     };
@@ -114,7 +114,7 @@ function handleVideoUpload(file) {
     reader.readAsArrayBuffer(file);
     reader.onloadend = function () {
         //for backend api asset needs only base64 part
-        window.assetFile = reader.result;
+        window.assetFile = Array.from(new Uint8Array(reader.result));
         window.assetName = file.type.replace('video/', 'asset.');
         checkUserUploadStatus();
     };


### PR DESCRIPTION
The issue is that video/audio file is converted to arrayBuffer after uploading but when changing the route to /publish and /publish-confirm, package data is stringified and applying JSON.Stringify to an arrayBuffer returns "".

I converted the arrayBuffer to an array on fileHandler.js and then converted back to arrayBuffer after parsing the JSON on publish-confirm just before uploading the package to github.

I couldn't try it because redirect URL after login to github always take me to "https://ar-js-org.github.io/studio/", not sure why. I tested the conversion of the arraybuffer and this "should" work. 

Maybe someone can give it a try and test this one out?