### PR TITLE
Fix: add upload info for .gltf

### DIFF
--- a/how-to-upload-gltf.md
+++ b/how-to-upload-gltf.md
@@ -1,0 +1,14 @@
+# How to upload .GLTF
+
+## Export your project with separated files
+In case you are using Blender you will have three options to export your .gltf file:
+
+1. glTF Binary (.glb)
+2. glTF Separate (.gltf + .bin + textures)
+3. glTF Embedded (.gltf)
+
+If you see the error message
+
+> *Please pack all related files to zip file and try again.
+
+then use option 2. glTF Separate (.gltf + .bin + textures), zip the files that have been exported with default settings and try again. Tested on Google Chrome on Macbook Pro 2019 (Intel chip), MacOS 12.1.

--- a/utils/fileHandler.js
+++ b/utils/fileHandler.js
@@ -163,7 +163,7 @@ function handleModelUpload(file) {
                 for (let i = 0; i < buffers.length; i++) {
                     uri = buffers[i].uri;
                     if (!reg4Base64.test(uri)) { // need a related file: data:application/octet-stream;base64,
-                        previewError.innerHTML = '*Please pack all related files to zip file and try again.'
+                        previewError.innerHTML = '*Please pack all related files to zip file and try again, consult <a class="link" target="_blank" href="https://github.com/AR-js-org/studio/blob/master/how-to-upload-gltf.md">this guide on uploading gltf.</a>'
 
                         return;
                     }
@@ -171,7 +171,7 @@ function handleModelUpload(file) {
                 for (let i = 0; i < images.length; i++) {
                     uri = images[i].uri;
                     if (!reg4Base64.test(uri)) { // need a related file
-                        previewError.innerHTML = '*Please pack all related files to zip file and try again.'
+                        previewError.innerHTML = '*Please pack all related files to zip file and try again, consult <a class="link" target="_blank" href="https://github.com/AR-js-org/studio/blob/master/how-to-upload-gltf.md">this guide on uploading gltf.</a>'
                         return;
                     }
                 }


### PR DESCRIPTION
As part of https://github.com/AR-js-org/studio/issues/119 I have created some suggestion code to give people a hand in uploading their .gltf files in order to streamline the AR.js Studio experience. I'm not well versed in JavaScript, so this is the easiest solution I came up with. I suppose that the <a> element will be parsed properly as innerHTML basically spews a string out into the HTML code, but feel free to correct me if I'm wrong.